### PR TITLE
fix video wallpaper problem

### DIFF
--- a/extra/wallpaper-creator/OnScreen/FinalPage.vala
+++ b/extra/wallpaper-creator/OnScreen/FinalPage.vala
@@ -87,7 +87,7 @@ namespace WallpaperCreator.OnScreen {
                 File.new_for_path(filePath).copy(File.new_for_path(dirPath + @"/$videoFileName"), FileCopyFlags.NONE);
                 
                 // Move the thumbnail
-                File.new_for_path(thumbnailPath).copy(File.new_for_path(dirPath + "/thumb.jpg"), FileCopyFlags.NONE);
+                File.new_for_path(thumbnailPath).copy(File.new_for_path(dirPath + "/wallpaper.jpg"), FileCopyFlags.NONE);
             
             } else {
 


### PR DESCRIPTION
It doesn't show a option to select the wallpaper when there's a thumb.jpg instead of wallpaper.jpg.
Alternate fix would be reading a thumb.jpg instead of a wallpaper.jpg but it's better to have all folders with a wallpaper.jpg i guess(same file name).

How to reproduce the original error:
Just create a video wallpaper, copy to Komorebi(the folder with resources in your system) and you'll not see it, it happened with me on Linux Mint.

//edit
Issues with/about this bug:
#80 #55 #51 #36
