### PR TITLE
Multimonitor support

### DIFF
--- a/src/OnScreen/AssetActor.vala
+++ b/src/OnScreen/AssetActor.vala
@@ -21,6 +21,8 @@ namespace Komorebi.OnScreen {
 
     public class AssetActor : Actor {
 
+        BackgroundWindow parent;
+
         // Image(Asset) and its pixbuf
         Image image = new Image();
         Gdk.Pixbuf pixbuf;
@@ -31,8 +33,8 @@ namespace Komorebi.OnScreen {
         string cloudsDirection = "right";
         string fadeType = "in";
 
-        public AssetActor () {
-
+        public AssetActor (BackgroundWindow parent) {
+            this.parent = parent;
             set_content(image);
         }
 
@@ -78,6 +80,7 @@ namespace Komorebi.OnScreen {
         }
 
         void setPosition() {
+            var mainActor = parent.mainActor;
 
             switch (assetPosition) {
 

--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -103,7 +103,7 @@ namespace Komorebi.OnScreen {
             embed = new GtkClutter.Embed() {width_request = screenWidth, height_request = screenHeight};
             mainActor = embed.get_stage();
             desktopPath = Environment.get_user_special_dir(UserDirectory.DESKTOP);
-            desktopIcons = new DesktopIcons();
+            desktopIcons = monitorIndex == 0 ? new DesktopIcons(this) : null;
             bubbleMenu = new BubbleMenu(this);
             assetActor = new AssetActor(this);
             dateTimeBox = new DateTimeBox(this);

--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -45,9 +45,6 @@ namespace Komorebi.OnScreen {
     // Global - Clipboard
     Gtk.Clipboard clipboard;
 
-    // Global - Desktop icons
-    DesktopIcons desktopIcons;
-
     public static void initializeClipboard(Gdk.Screen screen) {
         clipboard = Gtk.Clipboard.get_for_display (screen.get_display (), Gdk.SELECTION_CLIPBOARD);
     }
@@ -71,11 +68,14 @@ namespace Komorebi.OnScreen {
         // Date and time box itself
         DateTimeBox dateTimeBox;
 
+        // Asset Actor
+        AssetActor assetActor;
+
         // Bubble menu
         public BubbleMenu bubbleMenu { get; private set; }
 
-        // Asset Actor
-        AssetActor assetActor;
+        // Desktop icons
+        public DesktopIcons desktopIcons { get; private set; }
 
         // Current animation mode
         bool dateTimeBoxParallax = false;

--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -165,9 +165,8 @@ namespace Komorebi.OnScreen {
 
 			Rectangle rectangle;
 			var screen = Gdk.Screen.get_default ();
-            var display = screen.get_display ();
 
-            rectangle = display.get_monitor (monitorIndex).get_geometry ();
+            screen.get_monitor_geometry (monitorIndex, out rectangle);
 
 			screenHeight = rectangle.height;
 			screenWidth = rectangle.width;

--- a/src/OnScreen/BubbleMenu.vala
+++ b/src/OnScreen/BubbleMenu.vala
@@ -87,12 +87,12 @@ namespace Komorebi.OnScreen {
         void signalsSetup () {
 
             newFolderMenuItem.button_press_event.connect(() => {
-                desktopIcons.createNewFolder();
+                parent.desktopIcons.createNewFolder();
                 return true;
             });
 
             pasteMenuItem.button_press_event.connect(() => {
-                desktopIcons.copyToDesktop(clipboard.wait_for_text());
+                parent.desktopIcons.copyToDesktop(clipboard.wait_for_text());
                 return true;
             });
 
@@ -100,7 +100,7 @@ namespace Komorebi.OnScreen {
             changeWallpaperMenuItem.button_press_event.connect(() => {
 
                 if(showDesktopIcons)
-                    desktopIcons.fadeOut();
+                    parent.desktopIcons.fadeOut();
 
                 fadeOut();
 

--- a/src/OnScreen/BubbleMenu.vala
+++ b/src/OnScreen/BubbleMenu.vala
@@ -27,6 +27,8 @@ namespace Komorebi.OnScreen {
 
     public class BubbleMenu : Actor {
 
+        BackgroundWindow parent;
+
         // Horizontal Box Layout
         BoxLayout horizontalBoxLayout = new BoxLayout() {orientation = Orientation.VERTICAL, spacing = 5};
 
@@ -63,7 +65,8 @@ namespace Komorebi.OnScreen {
         }
 
 
-        public BubbleMenu () {
+        public BubbleMenu (BackgroundWindow parent) {
+            this.parent = parent;
 
             // Desktop items
             newFolderMenuItem = new BubbleMenuItem("New Folder");
@@ -216,7 +219,7 @@ namespace Komorebi.OnScreen {
                 x -= width + 15;
             }
 
-            if((y + height) >= mainActor.height)
+            if((y + height) >= parent.mainActor.height)
                 y -= (height + 10);
 
             opacity = 0;

--- a/src/OnScreen/BubbleMenu.vala
+++ b/src/OnScreen/BubbleMenu.vala
@@ -186,7 +186,7 @@ namespace Komorebi.OnScreen {
             } else {
 
                 // Dim all icons
-                foreach (var icon in iconsList)
+                foreach (var icon in parent.desktopIcons.iconsList)
                     icon.dimIcon();
 
                 // Check if we have anything in the clipboard,
@@ -248,7 +248,7 @@ namespace Komorebi.OnScreen {
             remove_all_children();
 
             // Undim all icon
-            foreach (var icon in iconsList)
+            foreach (var icon in parent.desktopIcons.iconsList)
                 icon.unDimIcon();
 
             icon = null;

--- a/src/OnScreen/DateTimeBox.vala
+++ b/src/OnScreen/DateTimeBox.vala
@@ -42,7 +42,11 @@ namespace Komorebi.OnScreen {
         // Ability to drag
         Clutter.DragAction dragAction = new Clutter.DragAction();
 
-        public DateTimeBox () {
+        BackgroundWindow parent;
+
+        public DateTimeBox (BackgroundWindow parent) {
+
+            this.parent = parent;
 
             // Properties
             textContainerActor.layout_manager = boxLayout;
@@ -172,6 +176,7 @@ namespace Komorebi.OnScreen {
         }
 
         public void setPosition() {
+            var mainActor = parent.mainActor;
 
             switch (dateTimePosition) {
 

--- a/src/OnScreen/DesktopIcons.vala
+++ b/src/OnScreen/DesktopIcons.vala
@@ -31,17 +31,21 @@ namespace Komorebi.OnScreen {
     // File/Directory info Window
     InfoWindow infoWindow;
 
-    // List of icons (used to make things faster when reloading)
-    Gee.ArrayList<Icon> iconsList;
-
     public class DesktopIcons : ResponsiveGrid {
+
+        BackgroundWindow parent;
+        public BackgroundWindow window { get { return parent; } }
 
         /* Desktops path */
         string DesktopPath = Environment.get_user_special_dir(UserDirectory.DESKTOP);
 
         FileMonitor fileMonitor;
 
-        public DesktopIcons () {
+        // List of icons (used to make things faster when reloading)
+        public Gee.ArrayList<Icon> iconsList { get; private set; }
+
+        public DesktopIcons (BackgroundWindow parent) {
+            this.parent = parent;
 
             infoWindow = new InfoWindow();
             iconsList = new Gee.ArrayList<Icon>();
@@ -127,7 +131,7 @@ namespace Komorebi.OnScreen {
                     Path = _KeyFile.get_string(KeyFileDesktop.GROUP, KeyFileDesktop.KEY_EXEC);
 
 
-                    icon = new Icon(Name, IconPixbuf, Path, DFile.get_path(), true);
+                    icon = new Icon(this, Name, IconPixbuf, Path, DFile.get_path(), true);
 
 
 
@@ -151,7 +155,7 @@ namespace Komorebi.OnScreen {
                         IconPixbuf = new Gdk.Pixbuf.from_file_at_scale(IconPath, iconSize, iconSize, false);
 
 
-                    icon = new Icon(Name, IconPixbuf, "", DFile.get_path(), false);
+                    icon = new Icon(this, Name, IconPixbuf, "", DFile.get_path(), false);
                 }
 
 
@@ -163,7 +167,7 @@ namespace Komorebi.OnScreen {
         /* Adds trash icon */
         private void addTrashIcon() {
 
-            iconsList.add(new Icon.Trash());
+            iconsList.add(new Icon.Trash(this));
         }
 
 
@@ -173,7 +177,7 @@ namespace Komorebi.OnScreen {
             var untitledFolder = File.new_for_path(getUntitledFolderName());
             untitledFolder.make_directory_async();
 
-            // var iconNewFolder = new Icon.NewFolder();
+            // var iconNewFolder = new Icon.NewFolder(this);
             // append(iconNewFolder);
             // iconNewFolder.unDimIcon(true);
 

--- a/src/OnScreen/Icon.vala
+++ b/src/OnScreen/Icon.vala
@@ -171,10 +171,20 @@ namespace Komorebi.OnScreen {
                             AppInfo.launch_default_for_uri (@"file://$filePath", null);
 
                         } else if(e.button == 3) { // Show the menu
+                            BubbleMenu bubbleMenu = null;
 
-                            bubbleMenu.fadeIn(e.x, e.y, MenuType.ICON);
-                            bubbleMenu.setIcon(this);
-                            backgroundWindow.dimWallpaper();
+                            foreach (BackgroundWindow backgroundWindow in backgroundWindows) {
+                                backgroundWindow.dimWallpaper();
+
+                                if (bubbleMenu == null && backgroundWindow.contains_point((int)e.x, (int)e.y)) {
+                                    bubbleMenu = backgroundWindow.bubbleMenu;
+                                }
+                            }
+
+                            if (bubbleMenu != null) {
+                                bubbleMenu.fadeIn(e.x, e.y, MenuType.ICON);
+                                bubbleMenu.setIcon(this);
+                            }
 
                             // Dim our text
                             titleText.opacity = 50;

--- a/src/OnScreen/Icon.vala
+++ b/src/OnScreen/Icon.vala
@@ -34,6 +34,8 @@ namespace Komorebi.OnScreen {
 
     public class Icon : Clutter.Actor {
 
+        DesktopIcons parent;
+
         /* Path of the file */
         public string filePath = "";
 
@@ -87,9 +89,9 @@ namespace Komorebi.OnScreen {
 
         }
 
-        public Icon (string name, Pixbuf pixbuf, string execPath, string filePath,
+        public Icon (DesktopIcons parent, string name, Pixbuf pixbuf, string execPath, string filePath,
                      bool isExecutable = false) {
-
+            this.parent = parent;
             this.filePath = filePath;
             this.execPath = execPath;
             this.titleName = name;
@@ -106,8 +108,8 @@ namespace Komorebi.OnScreen {
 
         }
 
-        public Icon.Trash () {
-
+        public Icon.Trash (DesktopIcons parent) {
+            this.parent = parent;
             this.titleName = "Trash";
             var pixbuf = Utilities.getIconFrom("user-trash", 64);
 
@@ -122,7 +124,8 @@ namespace Komorebi.OnScreen {
 
         }
 
-        public Icon.NewFolder () {
+        public Icon.NewFolder (DesktopIcons parent) {
+            this.parent = parent;
 
             var pixbuf = Utilities.getIconFrom("folder", 64);
 
@@ -171,26 +174,19 @@ namespace Komorebi.OnScreen {
                             AppInfo.launch_default_for_uri (@"file://$filePath", null);
 
                         } else if(e.button == 3) { // Show the menu
-                            BubbleMenu bubbleMenu = null;
+                            BackgroundWindow backgroundWindow = parent.window;
+                            BubbleMenu bubbleMenu = backgroundWindow.bubbleMenu;
 
-                            foreach (BackgroundWindow backgroundWindow in backgroundWindows) {
-                                backgroundWindow.dimWallpaper();
+                            backgroundWindow.dimWallpaper();
 
-                                if (bubbleMenu == null && backgroundWindow.contains_point((int)e.x, (int)e.y)) {
-                                    bubbleMenu = backgroundWindow.bubbleMenu;
-                                }
-                            }
-
-                            if (bubbleMenu != null) {
-                                bubbleMenu.fadeIn(e.x, e.y, MenuType.ICON);
-                                bubbleMenu.setIcon(this);
-                            }
+                            bubbleMenu.fadeIn(e.x, e.y, MenuType.ICON);
+                            bubbleMenu.setIcon(this);
 
                             // Dim our text
                             titleText.opacity = 50;
 
                             // Dim other icons
-                            foreach (var icon in iconsList) {
+                            foreach (var icon in parent.iconsList) {
                                 if(icon.filePath != this.filePath)
                                     icon.dimIcon();
                             }

--- a/src/OnScreen/PreferencesWindow.vala
+++ b/src/OnScreen/PreferencesWindow.vala
@@ -204,10 +204,13 @@ namespace Komorebi.OnScreen {
                 showDesktopIcons = showDesktopIconsButton.active;
                 updateConfigurationFile();
 
-                if(showDesktopIcons)
-                    desktopIcons.fadeIn();
-                else
-                    desktopIcons.fadeOut();
+                if (showDesktopIcons) {
+                    foreach (BackgroundWindow backgroundWindow in backgroundWindows)
+                        backgroundWindow.desktopIcons.fadeIn();
+                } else {
+                    foreach (BackgroundWindow backgroundWindow in backgroundWindows)
+                        backgroundWindow.desktopIcons.fadeOut();
+                }
             });
 
 			wallpapersSelector.wallpaperChanged.connect(() => {

--- a/src/OnScreen/Thumbnail.vala
+++ b/src/OnScreen/Thumbnail.vala
@@ -58,7 +58,11 @@ namespace Komorebi.OnScreen {
                 showBorder();
                 clicked();
                 
-                backgroundWindow.initializeConfigFile();
+                readWallpaperFile();
+
+                foreach (BackgroundWindow backgroundWindow in backgroundWindows) {
+                    backgroundWindow.initializeConfigFile();
+                }
                 updateConfigurationFile();
 
                 foreach(var thumbnail in thumbnailsList)


### PR DESCRIPTION
This PR adds multi-monitor support by creating a BackgroundWindow for each monitor. Each BackgroundWindow now owns its own instances of BubbleMenu, mainActor, and DesktopIcons (deliberately limited to the primary monitor for now though). Some BackgroundWindow agnostic code -- e.g. clipboard setup, readConfigurationFile and readWallpaperFile -- was moved out to Main instead.

Issues: #88 #84 

Love this project, by the way :+1: 